### PR TITLE
feat: add embedded export for pure embedded database usage

### DIFF
--- a/embedded.d.ts
+++ b/embedded.d.ts
@@ -1,0 +1,1 @@
+export { PluresDatabase, QueryResult, ExecutionResult, NodeWithMetadata, SearchResult, DatabaseStats, init } from './crates/pluresdb-node/index';

--- a/embedded.js
+++ b/embedded.js
@@ -1,0 +1,46 @@
+/**
+ * PluresDB Embedded - Pure embedded database (no server process required)
+ *
+ * Re-exports the native N-API bindings from @plures/pluresdb-native.
+ * Requires the native `.node` binary to be built first:
+ *   cd crates/pluresdb-node && npm run build
+ *
+ * Usage:
+ *   const { PluresDatabase } = require('@plures/pluresdb/embedded');
+ *   const db = new PluresDatabase('my-actor', '/tmp/my.db');
+ */
+
+const path = require('path');
+
+let nativeModule;
+try {
+  // Try loading the platform-specific binary via napi-rs conventions
+  const platformTriple = `${process.arch === 'x64' ? 'x86_64' : process.arch === 'arm64' ? 'aarch64' : process.arch}-${
+    process.platform === 'linux' ? 'unknown-linux-gnu' :
+    process.platform === 'darwin' ? 'apple-darwin' :
+    process.platform === 'win32' ? 'pc-windows-msvc' : process.platform
+  }`;
+
+  try {
+    // Try platform-specific package first (npm optional deps pattern)
+    nativeModule = require(`@plures/pluresdb-native-${platformTriple}`);
+  } catch {
+    // Fall back to local build output in crates/pluresdb-node/
+    nativeModule = require(path.join(__dirname, 'crates', 'pluresdb-node', `pluresdb-node.${process.platform}-${process.arch === 'x64' ? 'x86_64' : process.arch}-${process.platform === 'linux' ? 'gnu' : ''}.node`));
+  }
+} catch (err) {
+  // Final fallback: try loading index.js from the native crate directory
+  try {
+    nativeModule = require(path.join(__dirname, 'crates', 'pluresdb-node', 'index.js'));
+  } catch {
+    throw new Error(
+      `Failed to load PluresDB native bindings. ` +
+      `The native .node binary must be built first:\n` +
+      `  cd crates/pluresdb-node && npm run build\n` +
+      `Or install the pre-built binary: npm install @plures/pluresdb-native\n` +
+      `Original error: ${err.message}`
+    );
+  }
+}
+
+module.exports = nativeModule;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
       "require": "./dist/local-first/unified-api.js",
       "default": "./dist/local-first/unified-api.js"
     },
+    "./embedded": {
+      "types": "./embedded.d.ts",
+      "require": "./embedded.js",
+      "default": "./embedded.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {
@@ -102,6 +107,11 @@
     "legacy/",
     "examples/",
     "scripts/",
+    "embedded.js",
+    "embedded.d.ts",
+    "crates/pluresdb-node/index.d.ts",
+    "crates/pluresdb-node/index.js",
+    "crates/pluresdb-node/*.node",
     "README.md",
     "LICENSE",
     "package.json"

--- a/test-embedded.js
+++ b/test-embedded.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Test script for PluresDB embedded API.
+ * Requires native bindings to be built first:
+ *   cd crates/pluresdb-node && npm run build
+ */
+
+try {
+  const { PluresDatabase } = require('./embedded');
+
+  // Test with file-backed database
+  const db = new PluresDatabase('test-actor', '/tmp/pluresdb-embedded-test.db');
+  console.log('✅ PluresDatabase created');
+
+  // Test SQL operations
+  db.exec('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, val TEXT)');
+  console.log('✅ CREATE TABLE');
+
+  db.exec("INSERT INTO t (val) VALUES ('hello')");
+  console.log('✅ INSERT');
+
+  const result = db.query('SELECT * FROM t');
+  console.log('✅ SELECT result:', JSON.stringify(result, null, 2));
+
+  // Test CRDT operations
+  const nodeId = db.put('test-1', { type: 'greeting', message: 'hello world' });
+  console.log('✅ put:', nodeId);
+
+  const node = db.get('test-1');
+  console.log('✅ get:', JSON.stringify(node));
+
+  const meta = db.getWithMetadata('test-1');
+  console.log('✅ getWithMetadata:', JSON.stringify(meta));
+
+  const searchResults = db.search('hello');
+  console.log('✅ search:', JSON.stringify(searchResults));
+
+  const stats = db.stats();
+  console.log('✅ stats:', JSON.stringify(stats));
+
+  const actorId = db.getActorId();
+  console.log('✅ actorId:', actorId);
+
+  db.delete('test-1');
+  console.log('✅ delete');
+
+  console.log('\n🎉 All embedded API tests passed!');
+} catch (err) {
+  console.error('❌ Test failed:', err.message);
+  console.error('\nNote: Native bindings must be built first.');
+  console.error('Run: cd crates/pluresdb-node && npm run build');
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a `@plures/pluresdb/embedded` export path that re-exports the native N-API bindings from `crates/pluresdb-node/`. This allows using PluresDB as a pure embedded database without spawning a Deno subprocess server.

## Changes
- `embedded.js` — loader that finds and loads the native `.node` binary
- `embedded.d.ts` — TypeScript type re-exports  
- `test-embedded.js` — test script for the embedded API
- `package.json` — added `./embedded` export path and included native files

## Usage
```js
const { PluresDatabase } = require('@plures/pluresdb/embedded');
const db = new PluresDatabase('my-actor', '/tmp/my.db');
```

## Note
The native `.node` binary must be built (requires Rust toolchain):
```
cd crates/pluresdb-node && npm run build
```

Existing exports are unchanged — this is purely additive.

Closes #68