### PR TITLE
chore: apply org-standard automation files

### DIFF
--- a/.github/workflows/tech-doc-writer.yml
+++ b/.github/workflows/tech-doc-writer.yml
@@ -20,14 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
 
       - name: Gather diff context
         id: context
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD)
-          DIFF=$(git diff HEAD~1 HEAD -- ':(exclude)*.md' ':(exclude)*.yml' ':(exclude)*.json' ':(exclude).github/' ':(exclude)docs/' | head -500)
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$MERGE_SHA")
+          DIFF=$(git diff "$BASE_SHA" "$MERGE_SHA" -- ':(exclude)*.md' ':(exclude)*.yml' ':(exclude)*.json' ':(exclude).github/' ':(exclude)docs/' | head -500)
           SRC_CHANGES=$(echo "$CHANGED" | grep -vE '^\.(github|gitignore)|^(README|CHANGELOG|docs/|\.)|\.md$|\.yml$|\.json$' | head -1)
 
           if [ -z "$SRC_CHANGES" ]; then
@@ -62,7 +65,7 @@ jobs:
 
             const body = `## Documentation Update Required
 
-> ⚠️ **Do NOT assume existing docs are correct.** Verify all doc claims against the actual source code. Use \`git diff HEAD~1 HEAD\` as your source of truth.
+> ⚠️ **Do NOT assume existing docs are correct.** Verify all doc claims against the actual source code. Use the PR diff as your source of truth.
 
 PR #${prNum} (\`${prTitle}\`) merged code changes.
 


### PR DESCRIPTION
Adds missing standard automation files and hardens the `tech-doc-writer` workflow based on review feedback.

## Changes

- **Added** `.github/workflows/tech-doc-writer.yml` — auto-creates a documentation issue on PR merge
- **Fixed diff correctness**: checkout now uses `ref: merge_commit_sha` with `fetch-depth: 0` and diffs `base.sha..merge_commit_sha` from the PR event payload, ensuring the full PR change set is captured regardless of squash/rebase/merge strategy
- **Removed unused outputs**: dropped `pr_num`/`pr_title` from `$GITHUB_OUTPUT` in the `Gather diff context` step; the `github-script` step reads both values directly from `context.payload.pull_request`
- **Tightened permissions**: workflow uses least-privilege token scopes (`contents: read`, `issues: write`)
- **Replaced PAT with `GITHUB_TOKEN`**: eliminates the broader blast radius of a long-lived PAT
- **Fixed script injection risk**: PR title is no longer interpolated into JS source; read from `context.payload` instead
- **Aligned docs-skip filter** with Conventional Commit title convention (`docs:`, `docs(`, `chore(docs)`)

---
_Auto-generated by [repo-standards](https://github.com/plures/.github/blob/main/.github/workflows/repo-standards.yml)_

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.