### PR TITLE
ci: skip lifecycle workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/copilot-pr-lifecycle.yml
+++ b/.github/workflows/copilot-pr-lifecycle.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   lifecycle:
+    if: github.actor != 'dependabot[bot]'
     uses: plures/repo-template/.github/workflows/copilot-pr-lifecycle-reusable.yml@main
     secrets:
       COPILOT_PAT: ${{ secrets.COPILOT_PAT }}


### PR DESCRIPTION
## Problem

All 9 Dependabot dep-bump PRs (#303–#312) fail the `lifecycle / queue-advance` job with:

```
Error: Input required and not supplied: github-token
```

**Root cause:** Dependabot-triggered workflows don't have access to repo secrets. `secrets.COPILOT_PAT` resolves to empty, so `actions/github-script@v7` rejects the missing `github-token` input.

This also auto-created 10 ci-feedback issues (#313–#322).

## Fix

Add `if: github.actor != 'dependabot[bot]'` to the lifecycle caller job. Dependabot PRs still run normal CI (cargo check, clippy, tests, format, WASM — all green ✅). They just skip the Copilot merge queue, which is correct behavior.

## After merge

Close ci-feedback issues #313–#322 (stale — caused by this bug).