### PR TITLE
fix: memory-efficient storage — streaming iteration, right-sized HNSW index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "pluresdb-core",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-cli"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-core"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-node"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "chrono",
  "napi",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-procedures"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-procedures-macros"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-sea"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-storage"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-sync"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-wasm"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/pluresdb-core/src/lib.rs
+++ b/crates/pluresdb-core/src/lib.rs
@@ -244,7 +244,7 @@ impl VectorIndex {
 #[cfg(feature = "native")]
 impl Default for VectorIndex {
     fn default() -> Self {
-        Self::new(1_000_000)
+        Self::new(1_024)
     }
 }
 
@@ -302,7 +302,7 @@ impl BruteForceVectorIndex {
 #[cfg(not(feature = "native"))]
 impl Default for BruteForceVectorIndex {
     fn default() -> Self {
-        Self::new(1_000_000)
+        Self::new(1_024)
     }
 }
 
@@ -380,7 +380,7 @@ pub enum CrdtOperation {
 /// A simple conflict-free replicated data store backed by a concurrent map.
 pub struct CrdtStore {
     nodes: DashMap<NodeId, NodeRecord>,
-    vector_index: Arc<ActiveVectorIndex>,
+    vector_index: parking_lot::RwLock<Arc<ActiveVectorIndex>>,
     embedder: Option<Arc<dyn EmbedText>>,
     lm_plugin: Option<Arc<dyn PluresLmPlugin>>,
     #[cfg(feature = "native")]
@@ -401,7 +401,7 @@ impl std::fmt::Debug for CrdtStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CrdtStore")
             .field("nodes", &self.nodes.len())
-            .field("vector_index", &self.vector_index)
+            .field("vector_index", &*self.vector_index.read())
             .field("embedder", &self.embedder.is_some())
             .field("lm_plugin", &self.lm_plugin.as_ref().map(|p| p.plugin_id()))
             .finish()
@@ -412,7 +412,7 @@ impl Default for CrdtStore {
     fn default() -> Self {
         Self {
             nodes: DashMap::new(),
-            vector_index: Arc::new(ActiveVectorIndex::default()),
+            vector_index: parking_lot::RwLock::new(Arc::new(ActiveVectorIndex::default())),
             embedder: None,
             lm_plugin: None,
             persistence: None,
@@ -566,7 +566,7 @@ impl CrdtStore {
                 {
                     continue;
                 }
-                self.vector_index.insert(entry.key(), emb);
+                self.vector_index.read().insert(entry.key(), emb);
                 indexed += 1;
             }
         }
@@ -584,42 +584,64 @@ impl CrdtStore {
             None => return,
         };
         let expected_dim = self.embedder.as_ref().map(|e| e.dimension());
-        let nodes = match Self::storage_list(storage.as_ref()) {
-            Ok(nodes) => nodes,
-            Err(e) => {
-                tracing::error!(
-                    "[CrdtStore] build_vector_index_from_persistence failed: {}",
-                    e
-                );
-                return;
-            }
-        };
-        let mut indexed = 0usize;
-        for stored in nodes {
+
+        // First pass: count valid embeddings to right-size the HNSW index.
+        let mut embedding_count = 0usize;
+        let count_result = Self::storage_for_each(storage.as_ref(), &mut |stored: StoredNode| {
             let record = match serde_json::from_value::<NodeRecord>(stored.payload) {
                 Ok(r) => r,
-                Err(_) => continue,
+                Err(_) => return true,
             };
             if let Some(emb) = &record.embedding {
                 if let Some(dim) = expected_dim {
-                    if emb.len() != dim {
-                        continue;
-                    }
+                    if emb.len() != dim { return true; }
                 }
-                if emb.is_empty()
-                    || !emb.iter().all(|v| v.is_finite())
-                    || !emb.iter().any(|v| *v != 0.0)
-                {
-                    continue;
+                if !emb.is_empty() && emb.iter().all(|v| v.is_finite()) && emb.iter().any(|v| *v != 0.0) {
+                    embedding_count += 1;
                 }
-                self.vector_index.insert(&record.id, emb);
-                indexed += 1;
             }
+            true
+        });
+        if let Err(e) = count_result {
+            tracing::error!("[CrdtStore] counting embeddings from persistence failed: {}", e);
+            return;
         }
-        tracing::debug!(
-            "[CrdtStore] Loaded {} embeddings from storage into vector index",
-            indexed
-        );
+        if embedding_count == 0 {
+            tracing::debug!("[CrdtStore] No embeddings found in persistence; skipping index build");
+            return;
+        }
+
+        // Right-size: 2x actual count, minimum 1024.
+        let capacity = (embedding_count * 2).max(1024);
+        let new_index = Arc::new(ActiveVectorIndex::new(capacity));
+        tracing::info!("[CrdtStore] Building vector index: {} embeddings, capacity {}", embedding_count, capacity);
+
+        // Second pass: stream and insert embeddings.
+        let idx = new_index.clone();
+        let dim = expected_dim;
+        let insert_result = Self::storage_for_each(storage.as_ref(), &mut |stored: StoredNode| {
+            let record = match serde_json::from_value::<NodeRecord>(stored.payload) {
+                Ok(r) => r,
+                Err(_) => return true,
+            };
+            if let Some(emb) = &record.embedding {
+                if let Some(d) = dim {
+                    if emb.len() != d { return true; }
+                }
+                if !emb.is_empty() && emb.iter().all(|v| v.is_finite()) && emb.iter().any(|v| *v != 0.0) {
+                    idx.insert(&record.id, emb);
+                }
+            }
+            true
+        });
+        if let Err(e) = insert_result {
+            tracing::error!("[CrdtStore] build_vector_index_from_persistence failed: {}", e);
+            return;
+        }
+
+        // Swap in the right-sized index.
+        *self.vector_index.write() = new_index;
+        tracing::info!("[CrdtStore] Loaded {} embeddings into right-sized vector index (capacity {})", embedding_count, capacity);
     }
 
     #[cfg(feature = "native")]
@@ -681,6 +703,16 @@ impl CrdtStore {
     #[cfg(not(feature = "native"))]
     fn storage_list(storage: &dyn SyncStorageEngine) -> anyhow::Result<Vec<StoredNode>> {
         storage.list()
+    }
+
+    #[cfg(feature = "native")]
+    fn storage_for_each(storage: &dyn StorageEngine, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> anyhow::Result<()> {
+        block_on(storage.for_each(f))
+    }
+
+    #[cfg(not(feature = "native"))]
+    fn storage_for_each(storage: &dyn SyncStorageEngine, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> anyhow::Result<()> {
+        storage.for_each(f)
     }
 
     fn persist_node(&self, record: &NodeRecord) {
@@ -807,7 +839,7 @@ impl CrdtStore {
                 r
             });
         if emb_valid {
-            self.vector_index.insert(&id, &emb_clone);
+            self.vector_index.read().insert(&id, &emb_clone);
         }
         if let Some(entry) = self.nodes.get(&id) {
             self.persist_node(entry.value());
@@ -827,7 +859,7 @@ impl CrdtStore {
             .entry(node_id.to_string())
             .and_modify(|record| record.embedding = Some(embedding.clone()));
         if emb_valid {
-            self.vector_index.insert(node_id, &embedding);
+            self.vector_index.read().insert(node_id, &embedding);
         }
         if let Some(entry) = self.nodes.get(node_id) {
             self.persist_node(entry.value());
@@ -885,6 +917,31 @@ impl CrdtStore {
             .iter()
             .map(|entry| entry.value().clone())
             .collect()
+    }
+
+    /// Iterate over all nodes via a callback without collecting into a Vec.
+    ///
+    /// In-memory entries shadow stored counterparts.  Return `false` to stop.
+    pub fn for_each_sync(&self, f: &mut (dyn FnMut(&NodeRecord) -> bool + Send)) {
+        if let Some(storage) = &self.persistence {
+            let mut seen = std::collections::HashSet::new();
+            for entry in self.nodes.iter() {
+                seen.insert(entry.key().clone());
+                if !f(entry.value()) { return; }
+            }
+            let _ = Self::storage_for_each(storage.as_ref(), &mut |stored: StoredNode| {
+                let record = match serde_json::from_value::<NodeRecord>(stored.payload) {
+                    Ok(r) => r,
+                    Err(_) => return true,
+                };
+                if seen.contains(&record.id) { return true; }
+                f(&record)
+            });
+            return;
+        }
+        for entry in self.nodes.iter() {
+            if !f(entry.value()) { break; }
+        }
     }
 
     pub fn apply(&self, op: CrdtOperation) -> Result<Option<NodeId>, StoreError> {
@@ -971,7 +1028,7 @@ impl CrdtStore {
             self.vector_index_ready.store(true, Ordering::Release);
         }
 
-        let candidates = self.vector_index.search(query_embedding, limit);
+        let candidates = self.vector_index.read().search(query_embedding, limit);
         let now = Utc::now();
         let mut results: Vec<VectorSearchResult> = candidates
             .into_iter()

--- a/crates/pluresdb-node/src/lib.rs
+++ b/crates/pluresdb-node/src/lib.rs
@@ -650,25 +650,25 @@ impl PluresDatabase {
         store.build_vector_index() as u32
     }
 
-    /// Get database statistics
+    /// Get database statistics without loading all nodes into memory.
     #[napi]
     pub fn stats(&self) -> Result<serde_json::Value> {
         let store = self.store.clone();
+        let store = store.lock();
 
-        let records = {
-            let store = store.lock();
-            store.list()
-        };
-
+        let mut total_nodes = 0u64;
         let mut type_counts: HashMap<String, u32> = HashMap::new();
-        for record in &records {
+
+        store.for_each_sync(&mut |record| {
+            total_nodes += 1;
             if let Some(t) = record.data.get("type").and_then(|v| v.as_str()) {
                 *type_counts.entry(t.to_string()).or_insert(0) += 1;
             }
-        }
+            true
+        });
 
         Ok(serde_json::json!({
-            "totalNodes": records.len(),
+            "totalNodes": total_nodes,
             "typeCounts": type_counts,
         }))
     }

--- a/crates/pluresdb-storage/src/lib.rs
+++ b/crates/pluresdb-storage/src/lib.rs
@@ -105,6 +105,28 @@ pub trait SyncStorageEngine: Send + Sync {
     fn delete(&self, id: &str) -> Result<()>;
     /// Return all nodes currently held by this storage engine.
     fn list(&self) -> Result<Vec<StoredNode>>;
+
+    /// Return the total number of stored nodes without loading them into memory.
+    fn count(&self) -> Result<usize> {
+        Ok(self.list()?.len())
+    }
+
+    /// Iterate over nodes one at a time via callback, avoiding full
+    /// materialization.  Return `false` from `f` to stop early.
+    fn for_each(&self, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> Result<()> {
+        for node in self.list()? {
+            if !f(node) { break; }
+        }
+        Ok(())
+    }
+
+    /// Iterate over nodes whose ID starts with `prefix`.
+    fn for_each_by_prefix(&self, prefix: &str, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> Result<()> {
+        let prefix = prefix.to_string();
+        self.for_each(&mut |node: StoredNode| {
+            if node.id.starts_with(&prefix) { f(node) } else { true }
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +152,28 @@ pub trait StorageEngine: Send + Sync {
     async fn delete(&self, id: &str) -> Result<()>;
     /// Return all nodes currently held by this storage engine.
     async fn list(&self) -> Result<Vec<StoredNode>>;
+
+    /// Return the total number of stored nodes without loading them into memory.
+    async fn count(&self) -> Result<usize> {
+        Ok(self.list().await?.len())
+    }
+
+    /// Iterate over nodes one at a time via callback, avoiding full
+    /// materialization.  Return `false` from `f` to stop early.
+    async fn for_each(&self, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> Result<()> {
+        for node in self.list().await? {
+            if !f(node) { break; }
+        }
+        Ok(())
+    }
+
+    /// Iterate over nodes whose ID starts with `prefix`.
+    async fn for_each_by_prefix(&self, prefix: &str, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> Result<()> {
+        let prefix = prefix.to_string();
+        self.for_each(&mut |node: StoredNode| {
+            if node.id.starts_with(&prefix) { f(node) } else { true }
+        }).await
+    }
 }
 
 /// A non-persistent storage backend useful for tests and in-memory deployments.
@@ -272,6 +316,28 @@ impl SyncStorageEngine for SledStorage {
             out.push(Self::deserialize(value)?);
         }
         Ok(out)
+    }
+
+    fn count(&self) -> Result<usize> {
+        Ok(self.db.len())
+    }
+
+    fn for_each(&self, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> Result<()> {
+        for entry in self.db.iter() {
+            let (_, value) = entry?;
+            let node = Self::deserialize(value)?;
+            if !f(node) { break; }
+        }
+        Ok(())
+    }
+
+    fn for_each_by_prefix(&self, prefix: &str, f: &mut (dyn FnMut(StoredNode) -> bool + Send)) -> Result<()> {
+        for entry in self.db.scan_prefix(prefix.as_bytes()) {
+            let (_, value) = entry?;
+            let node = Self::deserialize(value)?;
+            if !f(node) { break; }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Problem

PluresLM-mcp with 3,880 memories (3.4M total nodes in sled) consumes **8GB+ RSS** on startup and grows to **12GB+** during operation. The database on disk is 3.3GB but the in-memory footprint is 3-4x that.

### Root causes

1. **HNSW pre-allocates 1M slots** — `VectorIndex::default()` creates a 1M-element HNSW index regardless of actual data size. Each slot stores neighbor lists + vector data. For 384-dim f32 vectors, this wastes ~1.5GB on an empty database.

2. **`list()` loads ALL nodes into memory** — `storage.list()` deserializes every sled entry into a `Vec<StoredNode>`. This is called by `build_vector_index_from_persistence()` (startup), `stats()`, `list()`, `list_by_type()`, `search_text()`, and other operations. With 3.4M nodes, each `list()` call allocates several GB.

3. **Updates waste HNSW slots** — `VectorIndex::insert()` always allocates a new slot index even for existing IDs. Stale ghost slots consume capacity without contributing to search.

## Solution

### Storage trait (`pluresdb-storage`)
- **`count()`** — returns node count without loading all into memory
- **`for_each()`** — streaming iteration via callback, one node at a time
- **`for_each_by_prefix()`** — leverages sled's `scan_prefix` for efficient filtered iteration
- All three have default implementations for backward compatibility
- `SledStorage` implements native efficient versions

### HNSW vector index (`pluresdb-core`)
- **`VectorIndex::default()`** now allocates **1,024 slots** instead of 1,000,000
- **`build_vector_index_from_persistence()`** now:
  1. First pass: streams nodes to count embeddings (no Vec allocation)
  2. Right-sizes HNSW to 2x actual count (minimum 1,024)
  3. Second pass: streams nodes to insert embeddings
  4. Swaps in the right-sized index via `RwLock`
- `vector_index` field: `Arc<VectorIndex>` → `RwLock<Arc<VectorIndex>>` for safe index replacement

### CrdtStore streaming
- **`for_each_sync()`** — iterates nodes via callback without collecting into Vec
- `stats()` in pluresdb-node uses `for_each_sync` instead of `list()`

## Impact

For a 3,880-memory database with 3.4M total nodes:
- **Before:** ~8GB RSS on startup
- **After:** ~2-3GB RSS (estimated — right-sized HNSW + streaming iteration)

## Tests

All existing tests pass. No breaking changes — all new methods have backward-compatible defaults.