### PR TITLE
fix(sea): revert pbkdf2 to 0.12 — resolve digest version conflict

### DIFF
--- a/crates/pluresdb-sea/Cargo.toml
+++ b/crates/pluresdb-sea/Cargo.toml
@@ -14,7 +14,7 @@ p256 = { version = "0.13", features = ["ecdh", "ecdsa"] }
 # SHA-256 hashing (used by ECDSA internally and for PBKDF2)
 sha2.workspace = true
 # PBKDF2 key derivation for SEA work/encrypt
-pbkdf2 = { version = "0.13", features = ["hmac"] }
+pbkdf2 = { version = "0.12", features = ["hmac"] }
 # AES-256-GCM symmetric encryption
 aes-gcm.workspace = true
 # Random number generation


### PR DESCRIPTION
Fixes CI compilation error in pluresdb-sea.

**Root cause:** Dependabot bumped pbkdf2 from 0.12→0.13. pbkdf2 0.13 requires \digest 0.11\ (\EagerHash\ trait), but the rest of the crypto stack (p256, ecdsa, elliptic-curve) depends on \digest 0.10\ (\Digest\ trait). This creates an irreconcilable trait mismatch.

**Fix:** Revert to pbkdf2 0.12 which uses digest 0.10. A full crypto stack upgrade (p256→0.14, ecdsa→0.17, etc) would be needed to use pbkdf2 0.13.