### PR TITLE
M6.4: re-export dataflow AST types under historical Px* names (consumer compat)

### DIFF
--- a/crates/pluresdb-px/src/px/mod.rs
+++ b/crates/pluresdb-px/src/px/mod.rs
@@ -43,6 +43,17 @@ pub use px_ast::{self, PxDocument, Statement};
 pub use px_compiler::{parse, parse_statement, CompileError};
 pub use px_eval;
 
+// M6.4 compat: pares-radix's `praxis` crate re-exports these dataflow AST types
+// under their historical `Px*` names (`crates/praxis/src/lib.rs`). The M6 AST
+// migration renamed them to px-ast's canonical `Dataflow*Decl`/`Dataflow*`
+// shapes; alias them back so downstream consumers that import
+// `pluresdb_px::px::PxDataflow{Procedure,Param,Return}` keep resolving without
+// source churn (the "transparent to consumers" contract of the SSOT re-export).
+pub use px_ast::{
+    DataflowParam as PxDataflowParam, DataflowProcedureDecl as PxDataflowProcedure,
+    DataflowReturn as PxDataflowReturn,
+};
+
 // Public expr renderer (Expr -> canonical executor source form). Re-exported so
 // external consumers (pluresdb-node's .px loader) reuse the ONE renderer rather
 // than duplicating it (ADR-0010).
@@ -54,6 +65,10 @@ pub use compiler::expr_to_string;
 pub mod pxlang {
     //! Alias of the crate's praxis-lang `.px` engine re-exports (see parent).
     pub use px_ast::{self, PxDocument, Statement};
+    pub use px_ast::{
+        DataflowParam as PxDataflowParam, DataflowProcedureDecl as PxDataflowProcedure,
+        DataflowReturn as PxDataflowReturn,
+    };
     pub use px_compiler::{parse, parse_statement, CompileError};
     pub use px_eval;
 }


### PR DESCRIPTION
## M6.4 (praxis-lang epic): complete the SSOT re-export shim for downstream consumers

**Context.** #1013 (M6.1-M6.3) migrated `pluresdb-px` onto praxis-lang as the single source of truth and added a names-only re-export hub in `px/mod.rs` intended to be transparent to `pares-radix` / `pares-agens`. It missed three names.

**Problem.** `pares-radix-praxis` (`crates/praxis/src/lib.rs`) re-exports:
```
pub use pluresdb_px::px::{ parse as parse_px, PxDataflowParam, PxDataflowProcedure, PxDataflowReturn };
```
M6 renamed those to px-ast's `DataflowProcedureDecl` / `DataflowParam` / `DataflowReturn`, so a straight `pluresdb-px` rev-bump to the M6 head (`6f5c9c1`) fails to compile downstream.

**Fix.** Purely-additive aliases in the re-export hub (and the `pxlang` back-compat submodule):
```
pub use px_ast::{
    DataflowParam as PxDataflowParam,
    DataflowProcedureDecl as PxDataflowProcedure,
    DataflowReturn as PxDataflowReturn,
};
```

**Validation (local, on disk).** Temp `[patch]` pointing `pares-radix`'s `pluresdb-px` at this branch:
- `cargo build -p pares-radix-praxis` -> **Finished** (fails without the aliases)
- `cargo build -p pares-radix-core -p pares-radix-audit -p pares-radix-agenda` -> **Finished**
- `pluresdb-px` unit tests: **472 passed / 0 failed**; `cargo fmt` clean.

No behavior change; type-alias only. Unblocks the pares-radix rev-bump step of M6.