### PR TITLE
fix(release): correct version baseline 3.0.1 -> 3.9.1 (unblock releases since May)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "pluresdb-core",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-chronos"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "chrono",
  "pluresdb-core",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-cli"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-core"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-node"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "chrono",
  "napi",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-procedures"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-procedures-macros"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-px"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-sea"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-storage"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-sync"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "pluresdb-wasm"
-version = "3.0.1"
+version = "3.9.1"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.1"
+version = "3.9.1"
 edition = "2021"
 authors = ["Plures Organization"]
 description = "P2P Graph Database — Local-first, offline-first database for modern applications"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plures/pluresdb",
-  "version": "3.0.1",
+  "version": "3.9.1",
   "description": "P2P Graph Database — Local-first, offline-first. One codebase: native Rust, Node.js (N-API), browser (WASM), Deno (WASM).",
   "type": "module",
   "main": "dist/node/index.js",


### PR DESCRIPTION
## Why there's been no pluresDB release since May

The `Release` workflow calls `plures/.github/release-reusable.yml`, whose `prepare` job detects `current_version` from **Cargo.toml `[workspace.package]`**. That value had drifted to **3.0.1**, while the actual published line (npm + git tags) is **3.9.1**.

Result: any bump (patch/minor/major) computed a version **below** the published `3.9.1`, so `npm publish` would reject it (can't publish a lower version) and the git tag would be wrong. Combined with the fact that the release only triggers on a `v*` tag or manual dispatch (and none was pushed), **173 commits have piled up unreleased since May**.

## Fix
Align both version sources to the real baseline:
- `Cargo.toml` `[workspace.package] version`: 3.0.1 -> 3.9.1
- `package.json` version: 3.0.1 -> 3.9.1

Crate manifests inherit `version.workspace = true`, so this covers the workspace.

## Verification (local, at the build seam)
- `cargo test --workspace --no-run` exits 0 — entire workspace compiles for test (this is exactly what the reusable workflow's Node `test` step runs: `cargo test --workspace`).
- The old May-13 ESM `require is not defined` crash in `tests/*.test.js` is NOT on the release path — the reusable workflow runs the package `"test"` script (`cargo test --workspace`), not `node --test` on those files.

## After merge
Trigger `Release` via `workflow_dispatch` with `bump: minor` -> lands **3.10.0**, clearing the backlog. (Or `target_version` for a milestone number.)
