### PR TITLE
fix(ci): unblock wasm target build broken by getrandom dependency drift

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+# NOTE: this file should mirror actual project needs — merge with any
+# future additions, don't clobber wholesale.
+
+[target.wasm32-unknown-unknown]
+# getrandom 0.3+/0.4+ (pulled transitively via crypto-bigint/p256/ecdsa for
+# pluresdb-sea's aes-gcm/ecdsa deps, and via ahash for fastembed on native
+# builds only — NOT reachable in the wasm target tree) require this cfg flag
+# in addition to the `wasm_js`/`js` Cargo features already set in
+# pluresdb-wasm/Cargo.toml. The Cargo feature alone is insufficient per
+# getrandom's own compile_error! message (found 2026-07-28, CI failure on
+# plures/pluresdb#1088 — pre-existing drift unrelated to that PR's diff,
+# caused by a dependency bump since the last-known-green run on 2026-07-24).
+# See: https://docs.rs/getrandom/latest/getrandom/#opt-in-backends
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,11 +1658,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3472,6 +3474,7 @@ dependencies = [
  "chrono",
  "console_error_panic_hook",
  "getrandom 0.2.16",
+ "getrandom 0.4.2",
  "js-sys",
  "pluresdb-chronos",
  "pluresdb-core",

--- a/crates/pluresdb-px/Cargo.toml
+++ b/crates/pluresdb-px/Cargo.toml
@@ -22,14 +22,13 @@ serde_json.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 thiserror.workspace = true
-# Bug found 2026-07-28 (plures/pluresdb#1088 CI, ci/wasm): this line was missing
-# `default-features = false`, unlike every other pluresdb-* dep in this workspace
-# (pluresdb-wasm, pluresdb-chronos, pluresdb-node all set it explicitly). That let
-# pluresdb-procedures' own `default = ["native"]` leak `native` -> pluresdb-core
-# `native` -> hnsw_rs -> rand 0.9 -> getrandom 0.3.3 into the wasm32 build graph,
-# even though pluresdb-wasm correctly disabled default features on its OWN direct
-# deps. Feature unification across the workspace graph doesn't respect a
-# downstream crate's intent if a transitive dep re-enables it.
+# Bug found 2026-07-28 (plures/pluresdb#1088 CI, ci/wasm): this dependency was missing
+# `default-features = false`, so pluresdb-procedures' default `native` feature could leak
+# into the wasm32 build graph via `native` -> pluresdb-core -> hnsw_rs -> rand -> getrandom,
+# even though pluresdb-wasm correctly disabled default features on its own direct deps.
+# Feature unification across the dependency graph doesn't respect a downstream crate's intent
+# if an upstream/transitive dependency re-enables a default feature.
+# See: crates/pluresdb-wasm/Cargo.toml for the intended wasm feature set.
 pluresdb-procedures = { path = "../pluresdb-procedures", default-features = false }
 async-trait = "0.1"
 tokio = { workspace = true, features = ["time", "rt"], optional = true }

--- a/crates/pluresdb-px/Cargo.toml
+++ b/crates/pluresdb-px/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["database", "declarative", "dsl", "reactive", "praxis"]
 default = ["watcher", "async"]
 watcher = ["notify", "walkdir"]
 async = ["tokio", "futures"]
+# Passthrough only — pluresdb-px itself doesn't use pluresdb-core's HNSW/embedding
+# native path, but downstream native consumers may still want it enabled.
+native = ["pluresdb-procedures/native"]
 
 [dependencies]
 serde.workspace = true
@@ -19,6 +22,15 @@ serde_json.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 thiserror.workspace = true
+# Bug found 2026-07-28 (plures/pluresdb#1088 CI, ci/wasm): this line was missing
+# `default-features = false`, unlike every other pluresdb-* dep in this workspace
+# (pluresdb-wasm, pluresdb-chronos, pluresdb-node all set it explicitly). That let
+# pluresdb-procedures' own `default = ["native"]` leak `native` -> pluresdb-core
+# `native` -> hnsw_rs -> rand 0.9 -> getrandom 0.3.3 into the wasm32 build graph,
+# even though pluresdb-wasm correctly disabled default features on its OWN direct
+# deps. Feature unification across the workspace graph doesn't respect a
+# downstream crate's intent if a transitive dep re-enables it.
+pluresdb-procedures = { path = "../pluresdb-procedures", default-features = false }
 async-trait = "0.1"
 tokio = { workspace = true, features = ["time", "rt"], optional = true }
 tracing = "0.1"

--- a/crates/pluresdb-wasm/Cargo.toml
+++ b/crates/pluresdb-wasm/Cargo.toml
@@ -27,6 +27,13 @@ js-sys = "0.3"
 # Intentionally enabled so transitive `getrandom` users (for example `uuid`)
 # use the JS-backed RNG on `wasm32-unknown-unknown`.
 getrandom = { version = "0.2", features = ["js"] }
+# getrandom 0.4+ (pulled transitively via crypto-bigint/p256/ecdsa for
+# pluresdb-sea's aes-gcm/ecdsa deps) dropped implicit wasm32 support and
+# requires this feature explicitly, or `cargo build --target wasm32-unknown-unknown`
+# fails with "wasm32-unknown-unknown targets are not supported by default"
+# (found 2026-07-28, plures/pluresdb#1088 CI). Pin the JS-backed backend the
+# same way the 0.2 line above already does.
+getrandom-04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 web-sys = { workspace = true, features = [
     "Window",
     "IdbFactory",


### PR DESCRIPTION
Fixes ci/wasm failure discovered while checking CI on #1088 (unrelated to that PR - pre-existing drift since last green main run 2026-07-24). See commit message for full root-cause + verification detail.