### PR TITLE
chore: add CODEOWNERS + SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,1 @@
 * @kbristol
-
-/crates/ @kbristol
-/types/ @kbristol
-/web/ @kbristol
-/modules/ @kbristol
-/azure/ @kbristol
-/e2e/ @kbristol
-/docs/ @kbristol
-/examples/ @kbristol
-/installer/ @kbristol
-/memory/ @kbristol
-/packaging/ @kbristol
-/scripts/ @kbristol
-/tests/ @kbristol
-/demo/ @kbristol
-/.cargo/ @kbristol
-/.github/ @kbristol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+* @kbristol
+
+/crates/ @kbristol
+/types/ @kbristol
+/web/ @kbristol
+/modules/ @kbristol
+/azure/ @kbristol
+/e2e/ @kbristol
+/docs/ @kbristol
+/examples/ @kbristol
+/installer/ @kbristol
+/memory/ @kbristol
+/packaging/ @kbristol
+/scripts/ @kbristol
+/tests/ @kbristol
+/demo/ @kbristol
+/.cargo/ @kbristol
+/.github/ @kbristol

--- a/.github/workflows/build-napi.yml
+++ b/.github/workflows/build-napi.yml
@@ -108,20 +108,20 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/*'
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -143,7 +143,7 @@ jobs:
           node test-node.js
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: crates/pluresdb-node/*.node
@@ -155,16 +155,16 @@ jobs:
     needs: build
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: crates/pluresdb-node/artifacts
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -65,13 +65,13 @@ jobs:
           - pluresdb-storage
           - pluresdb-px
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload mutants report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutants-report-${{ matrix.crate }}
           path: mutants-out/

--- a/.github/workflows/pluresdb-px-conformance.yml
+++ b/.github/workflows/pluresdb-px-conformance.yml
@@ -23,10 +23,10 @@ jobs:
   conformance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cargo test conformance
         run: cargo test -p pluresdb-px --test conformance --locked

--- a/.github/workflows/pr-lane-event-relay.yml
+++ b/.github/workflows/pr-lane-event-relay.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Dispatch lane tick to automation-infrastructure
         if: steps.preflight.outputs.enabled == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.PLURES_PROJECTS }}
           repository: plures/automation-infrastructure

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -23,10 +23,10 @@ jobs:
     name: Build web/svelte
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/*'
           cache: npm


### PR DESCRIPTION
Low-risk hygiene pilot (2026-08-04). Adds .github/CODEOWNERS (all paths -> @kbristol) and SHA-pins all third-party action refs (original tag kept as trailing comment). Internal plures/*@main reusable workflows untouched. Please review and merge.